### PR TITLE
Add Debian-focused Python .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,133 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# C extensions
+*.so
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Type checkers
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+.pytype/
+.ruff_cache/
+
+# Virtual environments
+.env
+.env.*
+.venv
+.venv/
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+.python-version
+
+# IDEs and editors
+.idea/
+.vscode/
+*.swp
+*.swo
+.project
+.pydevproject
+.spyderproject
+.spyproject
+.ropeproject
+
+# Jupyter / IPython
+.ipynb_checkpoints
+profile_default/
+ipython_config.py
+
+# Documentation builds
+site/
+_docs/_build/
+doc/_build/
+docs/_build/
+
+# Framework settings
+*.log
+local_settings.py
+instance/
+.webassets-cache
+
+# Django database files
+db.sqlite3
+db.sqlite3-journal
+
+# Scrapy project data
+.scrapy
+
+# PyBuilder
+target/
+
+# Coverage configuration
+*.coveragerc
+
+# Cython debug symbols
+cython_debug/
+
+# Local caches
+.local/
+
+# Debian packaging artifacts
+*.deb
+*.ddeb
+*.udeb
+*.build
+*.changes
+*.upload
+.debhelper/
+debian/.debhelper/
+debian/debhelper-build-stamp
+debian/files
+debian/*.substvars
+debian/*.log
+debian/.debhelper.log
+debian/tmp/
+debian/python3-*/
+_debuild/


### PR DESCRIPTION
## Summary
- add a repository-level .gitignore tailored for Python 3 projects on Debian, covering Python bytecode, tooling caches, and Debian packaging artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e599015430833381528f3a454967a5