### PR TITLE
docs: expose flask dev server to local network

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This project provides a small Flask web application for editing the `config_show
    ```bash
    pip install -r requirements.txt
    ```
-3. Run the development server:
+3. Run the development server (exposed to your local network):
    ```bash
-   flask --app app run --debug
+   flask --app app run --debug --host=0.0.0.0
    ```
-4. Open your browser to [http://localhost:5000](http://localhost:5000) to manage shows and stations.
+4. Open your browser to [http://localhost:5000](http://localhost:5000) or use your machine's local network IP (for example, `http://192.168.1.10:5000`) to manage shows and stations.
 
 Changes are saved directly back to the JSON files in the `config/` directory.


### PR DESCRIPTION
## Summary
- update the README to run the Flask development server with --host=0.0.0.0
- document that the UI can be accessed via the machine's local network IP

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59ab7cdb08333b850cb22f3895a43