### PR TITLE
Add instructional home page

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,7 @@ def inject_globals():
 
 @app.route("/")
 def home():
-    return redirect(url_for("list_shows"))
+    return render_template("home.html")
 
 
 @app.route("/shows")

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,6 +15,7 @@
       {% set show_endpoints = ['list_shows', 'create_show', 'edit_show'] %}
       {% set station_endpoints = ['list_stations', 'create_station', 'edit_station'] %}
       <ul>
+        <li><a href="{{ url_for('home') }}" class="{{ 'active' if request.endpoint == 'home' else '' }}">Home</a></li>
         <li><a href="{{ url_for('list_shows') }}" class="{{ 'active' if request.endpoint in show_endpoints else '' }}">Shows</a></li>
         <li><a href="{{ url_for('list_stations') }}" class="{{ 'active' if request.endpoint in station_endpoints else '' }}">Stations</a></li>
       </ul>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="instructions">
+  <h2>Getting Started</h2>
+  <p>Follow the steps below to configure the Radio Recorder:</p>
+  <ol>
+    <li>Ensure your radio station is created.</li>
+    <li>Create your show.</li>
+    <li>Manually put your JPEG artwork into the directory at <code>debian-04.lan:/home/alw/code/radio_recorder_host/config/art</code>.</li>
+    <li>Schedule a cron job on <code>debian-04.lan</code> with <code>crontab -e</code>.</li>
+  </ol>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated home page that explains how to configure the radio recorder
- update the global navigation to link to the new instructions

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e66fe52d808333806c4b0a6077d3b5