### PR TITLE
Adjust edit button layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -43,6 +43,12 @@ nav ul li a.active {
   margin: 0;
 }
 
+.table-wrapper table td.actions a[role="button"] {
+  display: inline-flex;
+  align-items: center;
+  padding-block: 0.25rem;
+}
+
 .form-card {
   padding: 2rem;
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- update the action button styling so edit buttons no longer render taller than delete buttons

## Testing
- manual: viewed the Shows page in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e67daad1c4833394de562a7e7e9537