### PR TITLE
Align edit button spacing with delete button

### DIFF
--- a/templates/shows/index.html
+++ b/templates/shows/index.html
@@ -28,7 +28,9 @@
               <td>{{ show['frequency'] }}</td>
               <td>{{ show['playlist-db-slug'] }}</td>
               <td class="actions">
-                <a role="button" href="{{ url_for('edit_show', show_key=key) }}">Edit</a>
+                <form action="{{ url_for('edit_show', show_key=key) }}" method="get">
+                  <button type="submit">Edit</button>
+                </form>
                 <form action="{{ url_for('delete_show', show_key=key) }}" method="post" onsubmit="return confirm('Delete show {{ key }}?');">
                   <button class="secondary" type="submit">Delete</button>
                 </form>

--- a/templates/stations/index.html
+++ b/templates/stations/index.html
@@ -22,7 +22,9 @@
               <td><code>{{ station_id }}</code></td>
               <td class="stream-url">{{ url }}</td>
               <td class="actions">
-                <a role="button" href="{{ url_for('edit_station', station_id=station_id) }}">Edit</a>
+                <form action="{{ url_for('edit_station', station_id=station_id) }}" method="get">
+                  <button type="submit">Edit</button>
+                </form>
                 <form action="{{ url_for('delete_station', station_id=station_id) }}" method="post" onsubmit="return confirm('Delete station {{ station_id }}?');">
                   <button class="secondary" type="submit">Delete</button>
                 </form>


### PR DESCRIPTION
## Summary
- switch edit actions to use form submit buttons so they share spacing with the delete buttons on both listing pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67f50f2188333accb8ba1fbc271ab