### PR TITLE
Improve table readability on shows and stations pages

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -22,12 +22,14 @@ nav ul li a.active {
 
 .table-wrapper table {
   min-width: 100%;
+  font-size: 0.9rem;
 }
 
 .table-wrapper table th,
 .table-wrapper table td {
   vertical-align: middle;
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .table-wrapper table td.stream-url {


### PR DESCRIPTION
## Summary
- decrease the font size used in table listings
- allow table cell contents to wrap and break words to prevent horizontal scrolling

## Testing
- manual verification

------
https://chatgpt.com/codex/tasks/task_e_68e68674f3e483339c99326984c17bc9