### PR TITLE
Rename Getting Started section to Quick Start

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <section class="instructions">
-  <h2>Getting Started</h2>
+  <h2>Quick Start</h2>
   <p>Follow the steps below to configure the Radio Recorder:</p>
   <ol>
     <li>Ensure your radio station is created.</li>


### PR DESCRIPTION
## Summary
- rename the home page instructions section heading from "Getting Started" to "Quick Start"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e68a986ac483339fc93ef136fda284