### PR TITLE
Add podcasts tab with RSS feed testing

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -65,6 +65,28 @@ nav ul li a.active {
   margin-top: 1.5rem;
 }
 
+.rss-input-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.rss-input-row input[type="url"] {
+  flex: 1 1 auto;
+}
+
+#test-status[data-state="loading"] {
+  color: #4b5563;
+}
+
+#test-status[data-state="success"] {
+  color: #065f46;
+}
+
+#test-status[data-state="error"] {
+  color: #991b1b;
+}
+
 .flash-messages {
   display: grid;
   gap: 0.5rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,10 +14,12 @@
       </ul>
       {% set show_endpoints = ['list_shows', 'create_show', 'edit_show'] %}
       {% set station_endpoints = ['list_stations', 'create_station', 'edit_station'] %}
+      {% set podcast_endpoints = ['list_podcasts', 'create_podcast', 'edit_podcast'] %}
       <ul>
         <li><a href="{{ url_for('home') }}" class="{{ 'active' if request.endpoint == 'home' else '' }}">Home</a></li>
         <li><a href="{{ url_for('list_shows') }}" class="{{ 'active' if request.endpoint in show_endpoints else '' }}">Shows</a></li>
         <li><a href="{{ url_for('list_stations') }}" class="{{ 'active' if request.endpoint in station_endpoints else '' }}">Stations</a></li>
+        <li><a href="{{ url_for('list_podcasts') }}" class="{{ 'active' if request.endpoint in podcast_endpoints else '' }}">Podcasts</a></li>
       </ul>
     </nav>
 
@@ -35,7 +37,7 @@
     </main>
 
     <footer class="container">
-      <small>Changes are written directly to <code>config/config_shows.json</code> and <code>config/config_stations.json</code>.</small>
+      <small>Changes are written directly to <code>config/config_shows.json</code>, <code>config/config_stations.json</code>, and <code>config/config_podcasts.json</code>.</small>
     </footer>
   </body>
 </html>

--- a/templates/podcasts/form.html
+++ b/templates/podcasts/form.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <article class="form-card">
+    <header>
+      <h1>{{ 'Add podcast' if not podcast_id else 'Edit podcast' }}</h1>
+      <p>Podcasts are stored in <code>config/config_podcasts.json</code>. Use the RSS feed tester to fetch metadata automatically.</p>
+    </header>
+    <form action="{{ form_action }}" method="post" class="stack" id="podcast-form" data-test-endpoint="{{ url_for('test_podcast_feed') }}">
+      <label for="podcast_id">Podcast ID</label>
+      <input type="text" id="podcast_id" name="podcast_id" value="{{ request.form.get('podcast_id', podcast_id) }}" required placeholder="e.g. daily-tech" autocomplete="off">
+      <small>This identifier is used as the key inside the configuration file.</small>
+
+      <label for="rss_feed">RSS feed URL</label>
+      <div class="rss-input-row">
+        <input type="url" id="rss_feed" name="rss_feed" value="{{ request.form.get('rss_feed', podcast_data['rss_feed']) }}" required placeholder="https://example.com/feed.xml">
+        <button type="button" class="secondary" id="test-rss">Test RSS</button>
+      </div>
+      <small id="test-status" role="status"></small>
+
+      <label for="author">Author</label>
+      <input type="text" id="author" name="author" value="{{ request.form.get('author', podcast_data['author']) }}" placeholder="Fetched from RSS feed">
+
+      <label for="last_build_date">Last build date</label>
+      <input type="text" id="last_build_date" name="last_build_date" value="{{ request.form.get('last_build_date', podcast_data['last_build_date']) }}" placeholder="Fetched from RSS feed">
+
+      {% if request.method == 'POST' %}
+        {% set download_checked = request.form.get('download_old_episodes') is not none %}
+      {% else %}
+        {% set download_checked = podcast_data['download_old_episodes'] %}
+      {% endif %}
+      <label class="checkbox">
+        <input type="checkbox" id="download_old_episodes" name="download_old_episodes" {% if download_checked %}checked{% endif %}>
+        <span>Download old episodes when first configured</span>
+      </label>
+
+      <footer class="form-actions">
+        <a role="button" class="secondary" href="{{ url_for('list_podcasts') }}">Cancel</a>
+        <button type="submit">Save podcast</button>
+      </footer>
+    </form>
+  </article>
+
+  <script>
+    (function () {
+      const form = document.getElementById('podcast-form');
+      if (!form) {
+        return;
+      }
+
+      const testButton = document.getElementById('test-rss');
+      const rssField = document.getElementById('rss_feed');
+      const authorField = document.getElementById('author');
+      const lastBuildField = document.getElementById('last_build_date');
+      const statusField = document.getElementById('test-status');
+
+      if (!testButton || !rssField || !statusField) {
+        return;
+      }
+
+      testButton.addEventListener('click', async () => {
+        const feedUrl = rssField.value.trim();
+        statusField.textContent = '';
+
+        if (!feedUrl) {
+          statusField.textContent = 'Enter an RSS feed URL to test.';
+          statusField.dataset.state = 'error';
+          return;
+        }
+
+        testButton.setAttribute('aria-busy', 'true');
+        statusField.textContent = 'Testing RSS feed…';
+        statusField.dataset.state = 'loading';
+
+        try {
+          const response = await fetch(form.dataset.testEndpoint, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ feed_url: feedUrl }),
+          });
+
+          const payload = await response.json();
+
+          if (!response.ok || !payload.success) {
+            const message = payload && payload.message ? payload.message : 'Unable to validate RSS feed.';
+            statusField.textContent = message;
+            statusField.dataset.state = 'error';
+            return;
+          }
+
+          if (authorField) {
+            authorField.value = payload.author || '';
+          }
+
+          if (lastBuildField) {
+            lastBuildField.value = payload.last_build_date || '';
+          }
+
+          statusField.textContent = 'RSS feed validated successfully.';
+          statusField.dataset.state = 'success';
+        } catch (error) {
+          statusField.textContent = 'Unable to validate RSS feed.';
+          statusField.dataset.state = 'error';
+        } finally {
+          testButton.removeAttribute('aria-busy');
+        }
+      });
+    })();
+  </script>
+{% endblock %}

--- a/templates/podcasts/index.html
+++ b/templates/podcasts/index.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <header class="page-header">
+    <h1>Podcasts</h1>
+    <a role="button" href="{{ url_for('create_podcast') }}">Add podcast</a>
+  </header>
+
+  {% if podcasts %}
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Podcast ID</th>
+            <th>RSS feed</th>
+            <th>Author</th>
+            <th>Last build date</th>
+            <th>Download old episodes?</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for podcast_id, data in podcasts.items() %}
+            <tr>
+              <td><code>{{ podcast_id }}</code></td>
+              <td class="stream-url">{{ data.get('rss_feed', '') }}</td>
+              <td>{{ data.get('author') or '—' }}</td>
+              <td>{{ data.get('last_build_date') or '—' }}</td>
+              <td>{{ 'Yes' if data.get('download_old_episodes') else 'No' }}</td>
+              <td class="actions">
+                <form action="{{ url_for('edit_podcast', podcast_id=podcast_id) }}" method="get">
+                  <button type="submit">Edit</button>
+                </form>
+                <form action="{{ url_for('delete_podcast', podcast_id=podcast_id) }}" method="post" onsubmit="return confirm('Delete podcast {{ podcast_id }}?');">
+                  <button class="secondary" type="submit">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p>No podcasts configured yet. Use the “Add podcast” button to create one.</p>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Podcasts tab with list, create, edit, and delete views backed by `config/config_podcasts.json`
- implement an RSS feed test endpoint that retrieves the channel author and last build date for display
- style the podcast form inputs and update navigation/footer references for the new configuration file

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ead29670a08333aaba5ec9395309f1