### PR TITLE
Add remote directory metadata to podcasts

### DIFF
--- a/config/config_podcasts.json
+++ b/config/config_podcasts.json
@@ -1,0 +1,9 @@
+{
+  "sample-podcast": {
+    "rss_feed": "https://example.com/feed.xml",
+    "author": "Sample Author",
+    "last_build_date": "Wed, 21 Jun 2023 07:00:00 GMT",
+    "download_old_episodes": false,
+    "remote_directory": "alwirtes@plex-server.lan:/Volumes/External_12tb/Podcasts/"
+  }
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -45,6 +45,23 @@ nav ul li a.active {
   margin: 0;
 }
 
+.table-wrapper table tr.podcast-remote-row td {
+  background: #f9fafb;
+  font-size: 0.85rem;
+  color: #374151;
+  padding-top: 0;
+}
+
+.table-wrapper table tr.podcast-remote-row td .label {
+  display: inline-block;
+  margin-right: 0.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
 .table-wrapper table td.actions a[role="button"] {
   display: inline-flex;
   align-items: center;

--- a/templates/podcasts/form.html
+++ b/templates/podcasts/form.html
@@ -24,6 +24,9 @@
       <label for="last_build_date">Last build date</label>
       <input type="text" id="last_build_date" name="last_build_date" value="{{ request.form.get('last_build_date', podcast_data['last_build_date']) }}" placeholder="Fetched from RSS feed">
 
+      <label for="remote_directory">Remote directory</label>
+      <input type="text" id="remote_directory" name="remote_directory" value="{{ request.form.get('remote_directory', podcast_data['remote_directory']) }}" required>
+
       {% if request.method == 'POST' %}
         {% set download_checked = request.form.get('download_old_episodes') is not none %}
       {% else %}

--- a/templates/podcasts/index.html
+++ b/templates/podcasts/index.html
@@ -36,6 +36,12 @@
                 </form>
               </td>
             </tr>
+            <tr class="podcast-remote-row">
+              <td colspan="6">
+                <span class="label">Remote directory</span>
+                <code>{{ data.get('remote_directory', default_remote_directory) }}</code>
+              </td>
+            </tr>
           {% endfor %}
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
- add a default remote directory for podcasts and persist it in the configuration data
- expose the remote directory field in the podcast form and list view with a second-row display
- include styling and a sample podcasts configuration that demonstrates the new field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ead75106b0833382d7ca2d1382df76